### PR TITLE
Changes Juju charm publish to on push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,15 +1,12 @@
 name: Publish Charm
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
 
 jobs:
   publish-charm:
-    if: github.event.pull_request.merged == true
     name: Publish Charm to edge
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Currently, the Juju charm publish job is triggered when a PR merges, but it will run on the merging branch instead of the main branch, causing it to fail it the merging branch does not have the necessary credentials.

When a Pull Request merges, it results in a push, triggering the job.