### PR TITLE
Delete unused actions.yaml file

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,5 +1,0 @@
-# Copyright 2021 Canonical
-# See LICENSE file for licensing details.
-
-# TODO(aznashwan):
-# add utility actions like returning the Mongo creds to the user


### PR DESCRIPTION
The file is empty, and newer versions of charmcraft (>= 2.4.0) has issues with this fact, causing the charm building actions to fail.